### PR TITLE
Use the Statamic authenticated user

### DIFF
--- a/src/Abstracts/EventListener.php
+++ b/src/Abstracts/EventListener.php
@@ -23,7 +23,7 @@ abstract class EventListener implements ShouldQueue
     protected function buildLogEntry(mixed $event): array
     {
         // if we have a user, get their details
-        $user = auth()->user();
+        $user = $event->authenticatedUser;
         if ($user) {
             $user = [
                 'id' => $user->id,


### PR DESCRIPTION
Hi there,

Following up on https://github.com/mitydigital/statamic-logger/issues/3, where the `auth()->user` is not available on all events dispatched via queues other than `sync`.

Statamic has `$event->authorizedUser` available, as mentioned here: https://github.com/statamic/cms/pull/9225

This PR should make it available in the log entries.