### PR TITLE
Return early when the user is not available

### DIFF
--- a/src/Listeners/User.php
+++ b/src/Listeners/User.php
@@ -20,6 +20,10 @@ class User extends EventListener
 
     protected function data($event): array
     {
+        if (is_null($event->user)) {
+            return [];
+        }
+
         return [
             'id' => $event->user->id,
             'name' => $event->user->name(),


### PR DESCRIPTION
Hi there,

When using this add-on we ran into an error that can sometimes occur when trying to log in:

```
`Attempt to read property \"id\" on null`
```

This is caused by the `Illuminate\Auth\Events\Failed` event, since it's possible for the event to have a `$user` property of `null`:

```php
/**
 * The user the attempter was trying to authenticate as.
 *
 * @var \Illuminate\Contracts\Auth\Authenticatable|null
 */
public $user;
```

This makes sure that, when this occurs, this does not crash. Not sure if you would like to log something else in this case since it's still inside the "User" listener? For now I've decided to just go with an empty array in this case.
