### PR TITLE
Fix space between checkboxes

### DIFF
--- a/resources/js/components/viewer.vue
+++ b/resources/js/components/viewer.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div id="logger-viewer">
         <header class="mb-6">
 
             <breadcrumb :url="breadcrumbUrl" :title="__('Utilities')"/>
@@ -213,3 +213,8 @@ export default {
     }
 }
 </script>
+<style>
+#logger-viewer .space-x-4 > * + * {
+    margin-left: 1rem
+}
+</style>


### PR DESCRIPTION
This only occurs when Two Factor is not installed - the space utility was added in the styles for Two Factor.